### PR TITLE
Add python port of generate_opn.sh

### DIFF
--- a/generate_opn.py
+++ b/generate_opn.py
@@ -127,3 +127,8 @@ with open(opn_file, 'w+b', buffering=0) as opn:
     header_checksum = hashlib.sha256(opn.read(4040))
     opn.seek(24)
     opn.write(header_checksum.digest())
+
+    # print checksums
+    print(f'Installer checksum: {installer_checksum.hexdigest()}')
+    print(f'Image checksum: {image_checksum.hexdigest()}')
+    print(f'Header checksum: {header_checksum.hexdigest()}')


### PR DESCRIPTION
This PR/branch adds a Python script that should be a nearly exact port of `generate_opn.sh`.

Despite a different GZIP checksum (because I'm using `import gzip` and not the `gzip` or `pigz` command), the Python script generates the exact same file as `generate_opn.sh`.

At HULKs, we are currently working on a Yocto image where this script will be used to generate the final OPN file.